### PR TITLE
Added support for `fields` option

### DIFF
--- a/src/Etsy/EtsyApi.php
+++ b/src/Etsy/EtsyApi.php
@@ -4,7 +4,7 @@ namespace Etsy;
 use Etsy\RequestValidator;
 
 /**
-* 
+*
 */
 class EtsyApi
 {
@@ -44,12 +44,16 @@ class EtsyApi
 
 		if (!empty($args['associations']))
 		{
-			$uri .= '?includes=' . $this->prepareAssociations($args['associations']);
+            $params['includes'] = $this->prepareAssociations($args['associations']);
+		}
+
+		if (!empty($args['fields']))
+		{
+            $params['fields'] = $this->prepareFields($args['fields']);
 		}
 
 		if(!empty($params)) {
-			$uri .= empty($args['associations']) ? "?" : "&";
-			$uri .= http_build_query($params);
+			$uri .= "?" . http_build_query($params);
 		}
 
 		return $this->validateResponse( $args, $this->client->request($uri, @$args['data'], $method['http_method'], $this->returnJson) );
@@ -119,6 +123,12 @@ class EtsyApi
 		return implode(',', $includes);
 	}
 
+	private function prepareFields($fields)
+	{
+
+		return implode(',', $fields);
+	}
+
 	private function buildAssociation($assoc, $conf)
 	{
 		$association = $assoc;
@@ -166,7 +176,8 @@ class EtsyApi
 																		'args' => array(
 																					'data' => @$validArguments['_valid'],
 																					'params' => @$args[0]['params'],
-																					'associations' => @$args[0]['associations']
+																					'associations' => @$args[0]['associations'],
+																					'fields' => @$args[0]['fields']
 																					)
 																	)));
 		} else {

--- a/src/Etsy/EtsyApi.php
+++ b/src/Etsy/EtsyApi.php
@@ -44,12 +44,12 @@ class EtsyApi
 
 		if (!empty($args['associations']))
 		{
-            $params['includes'] = $this->prepareAssociations($args['associations']);
+			$params['includes'] = $this->prepareAssociations($args['associations']);
 		}
 
 		if (!empty($args['fields']))
 		{
-            $params['fields'] = $this->prepareFields($args['fields']);
+			$params['fields'] = $this->prepareFields($args['fields']);
 		}
 
 		if(!empty($params)) {

--- a/src/test/Etsy/EtsyApiBuildRequestTest.php
+++ b/src/test/Etsy/EtsyApiBuildRequestTest.php
@@ -21,9 +21,9 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals($result, array('path' => '/', 'data' => array(), 'method' => 'GET'));
 	}
 
-    /**
-     * @expectedException Exception
-     */
+	/**
+	 * @expectedException Exception
+	 */
   	public function testInvalidMethod()
 	{
 		$this->api->getInvalidMethod();
@@ -44,9 +44,9 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 			'method' => 'GET'));
 	}
 
-    /**
-     * @expectedException Exception
-     */
+	/**
+	 * @expectedException Exception
+	 */
   	public function testInvalidParams()
 	{
 		$this->api->getCategory(array(
@@ -111,9 +111,9 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 			'method' => 'PUT'));
 	}
 
-    /**
-     * @expectedException Exception
-     */
+	/**
+	 * @expectedException Exception
+	 */
   	public function testInvalidData()
 	{
 		$this->api->getCategory(array(
@@ -123,9 +123,9 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 		));
 	}
 
-    /**
-     * @expectedException Exception
-     */
+	/**
+	 * @expectedException Exception
+	 */
   	public function testInvalidDataType()
 	{
 		$this->api->getCategory(array(
@@ -149,7 +149,7 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 
 		$result = $this->api->getListing($args);
 		$this->assertEquals($result, array(
-			'path' => '/listings/654321?includes=Images,ShippingInfo',
+			'path' => '/listings/654321?includes=' . urlencode('Images,ShippingInfo'),
 			'data' => array(),
 			'method' => 'GET'));
 	}
@@ -172,7 +172,7 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 
 		$result = $this->api->getListing($args);
 		$this->assertEquals($result, array(
-			'path' => '/listings/654321?includes=ShippingInfo(currency_code,primary_cost):active:1:0',
+			'path' => '/listings/654321?includes=' . urlencode('ShippingInfo(currency_code,primary_cost):active:1:0'),
 			'data' => array(),
 			'method' => 'GET'));
 	}
@@ -193,7 +193,7 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 
 		$result = $this->api->getListing($args);
 		$this->assertEquals($result, array(
-			'path' => '/listings/654321?includes=ShippingInfo:1:0',
+			'path' => '/listings/654321?includes=' . urlencode('ShippingInfo:1:0'),
 			'data' => array(),
 			'method' => 'GET'));
 	}
@@ -217,7 +217,7 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 
 		$result = $this->api->getListing($args);
 		$this->assertEquals($result, array(
-			'path' => '/listings/654321?includes=ShippingInfo/DestinationCountry(name,slug)',
+			'path' => '/listings/654321?includes=' . urlencode('ShippingInfo/DestinationCountry(name,slug)'),
 			'data' => array(),
 			'method' => 'GET'));
 	}
@@ -261,7 +261,7 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 
 		$result = $this->api->getListing($args);
 		$this->assertEquals($result, array(
-			'path' => '/listings/654321?includes=ShippingInfo(currency_code,primary_cost):active:1:0&limit=10&offset=20&page=3',
+			'path' => '/listings/654321?limit=10&offset=20&page=3&includes=' . urlencode('ShippingInfo(currency_code,primary_cost):active:1:0'),
 			'data' => array(),
 			'method' => 'GET'));
 	}

--- a/src/test/Etsy/EtsyApiBuildRequestTest.php
+++ b/src/test/Etsy/EtsyApiBuildRequestTest.php
@@ -24,12 +24,12 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * @expectedException Exception
 	 */
-  	public function testInvalidMethod()
+	public function testInvalidMethod()
 	{
 		$this->api->getInvalidMethod();
 	}
 
-  	public function testValidParams()
+	public function testValidParams()
 	{
 		$args = array(
 			'params' => array(
@@ -47,7 +47,7 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * @expectedException Exception
 	 */
-  	public function testInvalidParams()
+	public function testInvalidParams()
 	{
 		$this->api->getCategory(array(
 			'params' => array(
@@ -56,7 +56,7 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 		));
 	}
 
-  	public function testValidData()
+	public function testValidData()
 	{
 		$args = array(
 			'data' => array(
@@ -90,7 +90,7 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 			'method' => 'POST'));
 	}
 
-  	public function testValidParamsAndData()
+	public function testValidParamsAndData()
 	{
 		$args = array(
 			'params' => array(
@@ -114,7 +114,7 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * @expectedException Exception
 	 */
-  	public function testInvalidData()
+	public function testInvalidData()
 	{
 		$this->api->getCategory(array(
 			'data' => array(
@@ -126,7 +126,7 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * @expectedException Exception
 	 */
-  	public function testInvalidDataType()
+	public function testInvalidDataType()
 	{
 		$this->api->getCategory(array(
 			'data' => array(
@@ -135,7 +135,7 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 		));
 	}
 
-  	public function testSimpleAssociations()
+	public function testSimpleAssociations()
 	{
 		$args = array(
 			'params' => array(
@@ -154,7 +154,7 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 			'method' => 'GET'));
 	}
 
-  	public function testComposedAssociations()
+	public function testComposedAssociations()
 	{
 		$args = array(
 			'params' => array(
@@ -177,7 +177,7 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 			'method' => 'GET'));
 	}
 
-  	public function testComposedOptionalParamsAssociations()
+	public function testComposedOptionalParamsAssociations()
 	{
 		$args = array(
 			'params' => array(
@@ -198,7 +198,7 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 			'method' => 'GET'));
 	}
 
-  	public function testComposedSubAssociations()
+	public function testComposedSubAssociations()
 	{
 		$args = array(
 			'params' => array(
@@ -262,6 +262,78 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 		$result = $this->api->getListing($args);
 		$this->assertEquals($result, array(
 			'path' => '/listings/654321?limit=10&offset=20&page=3&includes=' . urlencode('ShippingInfo(currency_code,primary_cost):active:1:0'),
+			'data' => array(),
+			'method' => 'GET'));
+	}
+
+	// Fields Tests
+
+	public function testComposedFields()
+	{
+		$args = array(
+			'fields' => array(
+				'listing_id',
+				'title'
+			)
+		);
+
+		$result = $this->api->findAllListingActive($args);
+		$this->assertEquals($result, array(
+			'path' => '/listings/active?fields=' . urlencode('listing_id,title'),
+			'data' => array(),
+			'method' => 'GET'));
+	}
+
+	public function testComposedFieldsWithAssociation()
+	{
+		$args = array(
+			'fields' => array(
+				'listing_id',
+				'title'
+			),
+			'associations' => array(
+				'ShippingInfo' => array(
+					'scope' => 'active',
+					'limit' => 1,
+					'offset' => 0,
+					'select' => array('currency_code', 'primary_cost')
+				)
+			)
+		);
+
+		$result = $this->api->findAllListingActive($args);
+		$this->assertEquals($result, array(
+			'path' => '/listings/active?includes=' . urlencode('ShippingInfo(currency_code,primary_cost):active:1:0') . '&fields=' . urlencode('listing_id,title'),
+			'data' => array(),
+			'method' => 'GET'));
+	}
+
+	public function testComposedFieldsWithAssociationAndParams()
+	{
+		$args = array(
+			'fields' => array(
+				'listing_id',
+				'title'
+			),
+			'params' => array(
+				'listing_id' => 654321,
+				'limit' => 10,
+				'offset' => 20,
+				'page' => 3
+			),
+			'associations' => array(
+				'ShippingInfo' => array(
+					'scope' => 'active',
+					'limit' => 1,
+					'offset' => 0,
+					'select' => array('currency_code', 'primary_cost')
+				)
+			)
+		);
+
+		$result = $this->api->getListing($args);
+		$this->assertEquals($result, array(
+			'path' => '/listings/654321?limit=10&offset=20&page=3&includes=' . urlencode('ShippingInfo(currency_code,primary_cost):active:1:0') . '&fields=' . urlencode('listing_id,title'),
 			'data' => array(),
 			'method' => 'GET'));
 	}


### PR DESCRIPTION
Hey, thanks for the great library, needed to be hable to use the `fields` parameter to make a big request a bit faster, so here comes a patch, it works like expected:
```php
$api->findAllShopListingsActive(array(
            'params' => array(
                'shop_id' => xxx
            ),
            'associations' => array(
                'Images',
                'Translations'
            ),
            'fields' => array(
                'listing_id', 'title', 'description', 'price', 'quantity', 'tags', 'url'
            )
        ));
```

See here for more infos about the `fields` param: https://www.etsy.com/developers/documentation/getting_started/resources#section_fields