### PR TITLE
Update enum for when_made for createListing

### DIFF
--- a/src/Etsy/RequestValidator.php
+++ b/src/Etsy/RequestValidator.php
@@ -52,7 +52,9 @@ class RequestValidator
 			$result['_invalid'][] = 'Method not found';
 			return $result;
 		}
+
 		$methodsParams = $methodInfo['params'];
+
 		foreach ($args as $name => $arg)
 		{
 			if (isset($methodsParams[$name]))
@@ -85,16 +87,26 @@ class RequestValidator
 									case 'double':
 										$item_type = 'float';
 										break;
-								}								
+								}
 								$type = 'array('.$item_type.')';
 							}
 						}
 						break;
 				}
+
 				if ($validType !== $type)
 				{
-					if (substr($validType, 0, 4) === 'enum')
+					if( $validType === "boolean" && $type === "string" )
 					{
+						if( $arg === "false" || $arg === "true" )
+						{
+							$result['_valid'][$name] = $arg;
+						}
+						else
+						{
+							$result['_invalid'][] = RequestValidator::invalidParam($name, $arg, gettype($arg));
+						}
+					} elseif (substr($validType, 0, 4) === 'enum') {
 						if ($arg === 'enum' || !preg_match("@".preg_quote($arg)."@", $validType))
 						{
 							$result['_invalid'][] = 'Invalid enum data param "'.$name.'" value ('.$arg.'): valid values "'.$validType.'"';

--- a/src/Etsy/methods.json
+++ b/src/Etsy/methods.json
@@ -367,7 +367,7 @@
       "tags": "array(string)",
       "who_made": "enum(i_did, collective, someone_else)",
       "is_supply": "boolean",
-      "when_made": "enum(made_to_order, 2010_2015, 2000_2009, 1994_1999, before_1994, 1990_1993, 1980s, 1970s, 1960s, 1950s, 1940s, 1930s, 1920s, 1910s, 1900s, 1800s, 1700s, before_1700)",
+      "when_made": "enum(made_to_order, 2010_2016, 2000_2009, 1994_1999, before_1994, 1990_1993, 1980s, 1970s, 1960s, 1950s, 1940s, 1930s, 1920s, 1910s, 1900s, 1800s, 1700s, before_1700)",
       "recipient": "enum(men, women, unisex_adults, teen_boys, teen_girls, teens, boys, girls, children, baby_boys, baby_girls, babies, birds, cats, dogs, pets)",
       "occasion": "enum(anniversary, baptism, bar_or_bat_mitzvah, birthday, canada_day, chinese_new_year, cinco_de_mayo, confirmation, christmas, day_of_the_dead, easter, eid, engagement, fathers_day, get_well, graduation, halloween, hanukkah, housewarming, kwanza, prom, july_4th, mothers_day, new_baby, new_years, quinceanera, retirement, st_patricks_day, sweet_16, sympathy, thanksgiving, valentines, wedding)",
       "style": "array(string)"
@@ -425,7 +425,7 @@
       "tags": "array(string)",
       "who_made": "enum(i_did, collective, someone_else)",
       "is_supply": "boolean",
-      "when_made": "enum(made_to_order, 2010_2015, 2000_2009, 1994_1999, before_1994, 1990_1993, 1980s, 1970s, 1960s, 1950s, 1940s, 1930s, 1920s, 1910s, 1900s, 1800s, 1700s, before_1700)",
+      "when_made": "enum(made_to_order, 2010_2016, 2000_2009, 1994_1999, before_1994, 1990_1993, 1980s, 1970s, 1960s, 1950s, 1940s, 1930s, 1920s, 1910s, 1900s, 1800s, 1700s, before_1700)",
       "recipient": "enum(men, women, unisex_adults, teen_boys, teen_girls, teens, boys, girls, children, baby_boys, baby_girls, babies, birds, cats, dogs, pets)",
       "occasion": "enum(anniversary, baptism, bar_or_bat_mitzvah, birthday, canada_day, chinese_new_year, cinco_de_mayo, confirmation, christmas, day_of_the_dead, easter, eid, engagement, fathers_day, get_well, graduation, halloween, hanukkah, housewarming, kwanza, prom, july_4th, mothers_day, new_baby, new_years, quinceanera, retirement, st_patricks_day, sweet_16, sympathy, thanksgiving, valentines, wedding)",
       "style": "array(string)",

--- a/tests/Etsy/EtsyApiBuildRequestTest.php
+++ b/tests/Etsy/EtsyApiBuildRequestTest.php
@@ -76,7 +76,7 @@ class EtsyApiBuildRequestTest extends \PHPUnit_Framework_TestCase
 				"tags" => array('fashion, othertag'),
 				"who_made" => "collective",
 				"is_supply" => true,
-				"when_made" => "2010_2015",
+				"when_made" => "2010_2016",
 				"recipient" => "men",
 				"occasion" => "baptism",
 				"style" => array('style1, style2')

--- a/tests/Etsy/RequestValidatorTest.php
+++ b/tests/Etsy/RequestValidatorTest.php
@@ -134,7 +134,7 @@ class RequestValidatorTest extends \PHPUnit_Framework_TestCase
 	      "tags": "array(string)",
 	      "who_made": "enum(i_did, collective, someone_else)",
 	      "is_supply": "boolean",
-	      "when_made": "enum(made_to_order, 2010_2015, 2000_2009, 1994_1999, before_1994, 1990_1993, 1980s, 1970s, 1960s, 1950s, 1940s, 1930s, 1920s, 1910s, 1900s, 1800s, 1700s, before_1700)",
+	      "when_made": "enum(made_to_order, 2010_2016, 2000_2009, 1994_1999, before_1994, 1990_1993, 1980s, 1970s, 1960s, 1950s, 1940s, 1930s, 1920s, 1910s, 1900s, 1800s, 1700s, before_1700)",
 	      "recipient": "enum(men, women, unisex_adults, teen_boys, teen_girls, teens, boys, girls, children, baby_boys, baby_girls, babies, birds, cats, dogs, pets)",
 	      "occasion": "enum(anniversary, baptism, bar_or_bat_mitzvah, birthday, canada_day, chinese_new_year, cinco_de_mayo, confirmation, christmas, day_of_the_dead, easter, eid, engagement, fathers_day, get_well, graduation, halloween, hanukkah, housewarming, kwanza, prom, july_4th, mothers_day, new_baby, new_years, quinceanera, retirement, st_patricks_day, sweet_16, sympathy, thanksgiving, valentines, wedding)",
 	      "style": "array(string)"

--- a/tests/Etsy/methods.json
+++ b/tests/Etsy/methods.json
@@ -366,7 +366,7 @@
       "tags": "array(string)",
       "who_made": "enum(i_did, collective, someone_else)",
       "is_supply": "boolean",
-      "when_made": "enum(made_to_order, 2010_2015, 2000_2009, 1994_1999, before_1994, 1990_1993, 1980s, 1970s, 1960s, 1950s, 1940s, 1930s, 1920s, 1910s, 1900s, 1800s, 1700s, before_1700)",
+      "when_made": "enum(made_to_order, 2010_2016, 2000_2009, 1994_1999, before_1994, 1990_1993, 1980s, 1970s, 1960s, 1950s, 1940s, 1930s, 1920s, 1910s, 1900s, 1800s, 1700s, before_1700)",
       "recipient": "enum(men, women, unisex_adults, teen_boys, teen_girls, teens, boys, girls, children, baby_boys, baby_girls, babies, birds, cats, dogs, pets)",
       "occasion": "enum(anniversary, baptism, bar_or_bat_mitzvah, birthday, canada_day, chinese_new_year, cinco_de_mayo, confirmation, christmas, day_of_the_dead, easter, eid, engagement, fathers_day, get_well, graduation, halloween, hanukkah, housewarming, kwanza, prom, july_4th, mothers_day, new_baby, new_years, quinceanera, retirement, st_patricks_day, sweet_16, sympathy, thanksgiving, valentines, wedding)",
       "style": "array(string)"
@@ -423,7 +423,7 @@
       "tags": "array(string)",
       "who_made": "enum(i_did, collective, someone_else)",
       "is_supply": "boolean",
-      "when_made": "enum(made_to_order, 2010_2015, 2000_2009, 1994_1999, before_1994, 1990_1993, 1980s, 1970s, 1960s, 1950s, 1940s, 1930s, 1920s, 1910s, 1900s, 1800s, 1700s, before_1700)",
+      "when_made": "enum(made_to_order, 2010_2016, 2000_2009, 1994_1999, before_1994, 1990_1993, 1980s, 1970s, 1960s, 1950s, 1940s, 1930s, 1920s, 1910s, 1900s, 1800s, 1700s, before_1700)",
       "recipient": "enum(men, women, unisex_adults, teen_boys, teen_girls, teens, boys, girls, children, baby_boys, baby_girls, babies, birds, cats, dogs, pets)",
       "occasion": "enum(anniversary, baptism, bar_or_bat_mitzvah, birthday, canada_day, chinese_new_year, cinco_de_mayo, confirmation, christmas, day_of_the_dead, easter, eid, engagement, fathers_day, get_well, graduation, halloween, hanukkah, housewarming, kwanza, prom, july_4th, mothers_day, new_baby, new_years, quinceanera, retirement, st_patricks_day, sweet_16, sympathy, thanksgiving, valentines, wedding)",
       "style": "array(string)",


### PR DESCRIPTION
https://www.etsy.com/developers/documentation/reference/listing#method_createlisting
2010_2015 is not valid anymore because throws an exception in the server side

The validations for booleans as strings was because i had a exception on  updateListingVariation on param is_available, the true value works well but false doesn't
https://www.etsy.com/developers/documentation/getting_started/api_basics#type_boolean

TODO update the test for booleans