### PR TITLE
Allow language parameter

### DIFF
--- a/src/Etsy/EtsyApi.php
+++ b/src/Etsy/EtsyApi.php
@@ -94,7 +94,7 @@ class EtsyApi
 
 	private function prepareParameters($params) {
 		$query_pairs = array();
-		$allowed = array("limit", "offset", "page", "sort_on", "sort_order", "include_private");
+		$allowed = array("limit", "offset", "page", "sort_on", "sort_order", "include_private", "language");
 
 		if ($params) {
 			foreach($params as $key=>$value) {


### PR DESCRIPTION
For some specific calls like e.g. finAllTopCategory etsy allows an extra "language" parameter to be sent. This change enables this extra parameter.