### PR TITLE
Switch token requests to force GET method. Resolves #42

### DIFF
--- a/src/Etsy/EtsyClient.php
+++ b/src/Etsy/EtsyClient.php
@@ -82,7 +82,7 @@ class EtsyClient
 	    	$callback = $extra['callback'];
 	    }
 	    try {
-		return $this->oauth->getRequestToken($url, $callback);
+		return $this->oauth->getRequestToken($url, $callback, 'GET');
 	    } catch (\OAuthException $e) {
 	        throw new EtsyRequestException($e, $this->oauth);
 	    }
@@ -93,7 +93,7 @@ class EtsyClient
 	public function getAccessToken($verifier)
 	{
 	    try {
-			return $this->oauth->getAccessToken($this->base_url . "/oauth/access_token", null, $verifier);
+			return $this->oauth->getAccessToken($this->base_url . "/oauth/access_token", null, $verifier, 'GET');
 	    } catch (\OAuthException $e) {
 	        throw new EtsyRequestException($e, $this->oauth);
 	    }


### PR DESCRIPTION
Authenticating a new app with Etsy now requires GET calls. Using a POST
request will throw a `411 Length Required` error.